### PR TITLE
chore: MySQLのバージョンをRDSサポートされているものに合わせる

### DIFF
--- a/docker/mysql.Dockerfile
+++ b/docker/mysql.Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8
+FROM mysql:8.0.35
 
 ENV TZ "Asia/Tokyo"
 


### PR DESCRIPTION
`docker/mysql.Dockerfile`で指定しているベースイメージが`FROM mysql:8`で、このまま起動すると8.4.0になってしまう。

```
mysql> select  version();
+-----------+
| version() |
+-----------+
| 8.4.0     |
+-----------+
1 row in set (0.00 sec)
```

RDSは8.0.xまでしか公式サポートしていないので、ローカル環境もそれに合わせておきたいのでベースイメージを変更した。

# 変更内容

- ローカルのMySQLのバージョンを8.0.35に変更
  - AWS環境と同じものに設定した: https://github.com/givery-bootcamp/dena-training-env/blob/6f35a74221be39879183b433d259587e30494462/dena-2024/rds.tf#L5
  - RDS MySQLサポートバージョン状況: https://docs.aws.amazon.com/ja_jp/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
  - MySQL Docker image: https://hub.docker.com/_/mysql

# 備考

あんまりちゃんと読み込めてないが、8.0->8.4で結構差分ありそう

https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html