### PR TITLE
chore: カバレッジ計測対象からswagger生成のgoファイル除外

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./backend
         run: |
           go test -tags="unit_test" ./... --cover -v -coverprofile=../coverage.out.tmp
-          cat ../coverage.out.tmp | grep -v "myapp/docs/docs.go" > ../coverage.out
-          rm ../coverage.out.tmp
+          grep -v "myapp/docs/docs.go" coverage.out > coverage_filtered.out
+          mv coverage_filtered.out coverage.out
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Test
         working-directory: ./backend
-        run: go test -tags="unit_test" ./... --cover -v -coverprofile=../coverage.out
+        run: |
+          go test -tags="unit_test" ./... --cover -v -coverprofile=../coverage.out.tmp
+          cat ../coverage.out.tmp | grep -v "myapp/docs/docs.go" > ../coverage.out
+          rm ../coverage.out.tmp
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Test
         working-directory: ./backend
         run: |
-          go test -tags="unit_test" ./... --cover -v -coverprofile=../coverage.out.tmp
-          grep -v "myapp/docs/docs.go" coverage.out > coverage_filtered.out
-          mv coverage_filtered.out coverage.out
+          go test -tags="unit_test" ./... --cover -v -coverprofile=cover.out.tmp
+          grep -v "myapp/docs/docs.go" cover.out.tmp > cover.out
+          rm cover.out.tmp
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./backend
         run: |
           go test -tags="unit_test" ./... --cover -v -coverprofile=coverage.out.tmp
-          grep -v "myapp/docs/docs.go" coverage.out.tmp > coverage.out
+          grep -v "myapp/docs/docs.go" coverage.out.tmp > ../coverage.out
           rm coverage.out.tmp
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Test
         working-directory: ./backend
         run: |
-          go test -tags="unit_test" ./... --cover -v -coverprofile=cover.out.tmp
-          grep -v "myapp/docs/docs.go" cover.out.tmp > cover.out
-          rm cover.out.tmp
+          go test -tags="unit_test" ./... --cover -v -coverprofile=coverage.out.tmp
+          grep -v "myapp/docs/docs.go" coverage.out.tmp > coverage.out
+          rm coverage.out.tmp
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ test:
 
 .PHONY: test-cover
 test-cover:
-	@cd backend; go test -v -p=1 -cover -tags="unit_test" ./... -coverprofile=cover.out
+	@cd backend; go test -v -p=1 -cover -tags="unit_test" ./... -coverprofile=cover.out.tmp
+	@cd backend; cat cover.out.tmp | grep -v "myapp/docs/docs.go" > cover.out
+	@cd backend; rm cover.out.tmp
 	@cd backend; go tool cover -html=cover.out -o cover.html
 	@open ./backend/cover.html

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 .PHONY: test-cover
 test-cover:
 	@cd backend; go test -v -p=1 -cover -tags="unit_test" ./... -coverprofile=cover.out.tmp
-	@cd backend; cat cover.out.tmp | grep -v "myapp/docs/docs.go" > cover.out
+	@cd backend; grep -v "myapp/docs/docs.go" cover.out.tmp > cover.out
 	@cd backend; rm cover.out.tmp
 	@cd backend; go tool cover -html=cover.out -o cover.html
 	@open ./backend/cover.html

--- a/backend/internal/infrastructure/persistence/datastore/post_repository.go
+++ b/backend/internal/infrastructure/persistence/datastore/post_repository.go
@@ -85,7 +85,6 @@ func (r *PostRepository) Update(ctx context.Context, post *model.Post) (*model.P
 
 func (r *PostRepository) Delete(ctx context.Context, id int) error {
 	conn := r.db.GetDB(ctx)
-
 	tx := conn.Begin()
 	if tx.Error != nil {
 		return xerrors.Errorf("failed to begin transaction: %w", tx.Error)

--- a/backend/internal/infrastructure/persistence/datastore/post_repository.go
+++ b/backend/internal/infrastructure/persistence/datastore/post_repository.go
@@ -85,6 +85,7 @@ func (r *PostRepository) Update(ctx context.Context, post *model.Post) (*model.P
 
 func (r *PostRepository) Delete(ctx context.Context, id int) error {
 	conn := r.db.GetDB(ctx)
+
 	tx := conn.Begin()
 	if tx.Error != nil {
 		return xerrors.Errorf("failed to begin transaction: %w", tx.Error)


### PR DESCRIPTION
`go test`ツールでうまくできなさそうだったので、以下の記事にしたがってcoverageファイルの中身を直接いじるようにした

https://qiita.com/ryoya-s/items/1eec81bea8671da3de18

これをやってカバレッジ19.3%->26.9%まであがった