### PR TITLE
chore: カバレッジ取るためにmainへのpushでもテスト回す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - backend/**
+  push:
+    branches:
+      - main
 
 jobs:
   e2e-test:


### PR DESCRIPTION
octocovでmainとのカバレッジ差分とっているので、mainにpushされるたびにテスト回してカバレッジ情報更新するようにした

※今のままだと、一生昔のmainブランチのカバレッジとの差分が出てしまう