### PR TITLE
chore: main.goとrouterをカバレッジから除外

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: ./backend
         run: |
           go test -tags="unit_test" ./... --cover -v -coverprofile=coverage.out.tmp
-          grep -v "myapp/docs/docs.go" coverage.out.tmp > ../coverage.out
+          grep  -Ev "myapp/docs/docs.go|myapp/main.go|myapp/internal/interface/api/router" coverage.out.tmp > ../coverage.out
           rm coverage.out.tmp
       - name: Exec octocov action
         uses: k1LoW/octocov-action@v0

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 .PHONY: test-cover
 test-cover:
 	@cd backend; go test -v -p=1 -cover -tags="unit_test" ./... -coverprofile=cover.out.tmp
-	@cd backend; grep -v "myapp/docs/docs.go" cover.out.tmp > cover.out
+	@cd backend; grep -Ev "myapp/docs/docs.go|myapp/main.go|myapp/internal/interface/api/router" cover.out.tmp > cover.out
 	@cd backend; rm cover.out.tmp
 	@cd backend; go tool cover -html=cover.out -o cover.html
 	@open ./backend/cover.html

--- a/backend/internal/interface/api/router/router.go
+++ b/backend/internal/interface/api/router/router.go
@@ -16,7 +16,6 @@ func CreateRouter() *gin.Engine {
 	app.Use(middleware.Cors())
 
 	db := driver.NewDB()
-
 	hr := datastore.NewHelloWorldRepository(db)
 	pr := datastore.NewPostRepository(db)
 	ur := datastore.NewUserRepository(db)

--- a/backend/internal/interface/api/router/router.go
+++ b/backend/internal/interface/api/router/router.go
@@ -16,6 +16,7 @@ func CreateRouter() *gin.Engine {
 	app.Use(middleware.Cors())
 
 	db := driver.NewDB()
+
 	hr := datastore.NewHelloWorldRepository(db)
 	pr := datastore.NewPostRepository(db)
 	ur := datastore.NewUserRepository(db)


### PR DESCRIPTION
ユニットテストはとても書きづらいので、E2Eでカバーするとしてカバレッジからは除外